### PR TITLE
fix: add line break in blockquote for proper formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ AI:  ✓ Reads AGENTS.md
 **No configuration. No learning curve. Just results.**
 
 > **Using Claude Code with TypeScript?**
+>
 > Check out **[AI Coding Project Boilerplate](https://github.com/shinpr/ai-coding-project-boilerplate)** - a specialized alternative optimized for that specific stack.
 
 ## Quick Start (30 seconds)


### PR DESCRIPTION
Add empty line in blockquote to ensure text renders on separate lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)