### PR TITLE
chore: bump minimum Node.js to >=22 and version to 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-code",
-  "version": "0.6.8",
+  "version": "0.7.0",
   "description": "Task-oriented context engineering framework for LLM coding agents - AGENTS.md standard compliant",
   "files": [
     "bin/",
@@ -36,6 +36,6 @@
   },
   "homepage": "https://github.com/shinpr/agentic-code#readme",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- Bump minimum Node.js engine requirement from `>=20.0.0` to `>=22.0.0`
- Bump package version from `0.6.8` to `0.7.0`

## Test plan
- [x] Metadata-only change in `package.json`, no logic affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)